### PR TITLE
Handle custom classNames in Field template

### DIFF
--- a/src/lib/FieldTemplate/FieldTemplate.tsx
+++ b/src/lib/FieldTemplate/FieldTemplate.tsx
@@ -12,6 +12,7 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
   required,
   schema,
   label,
+  classNames
 }: FieldTemplateProps) => {
   // simply return children, we don't want an object is wrapped in Form.Item
   // every property should have their own Form.Item wrapper
@@ -25,7 +26,8 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
       required={required}
       label={displayLabel && schema.title}
       htmlFor={id}
-      id={id}>
+      id={id}
+      className={classNames}>
       {children}
       {displayLabel && rawDescription ? <Typography>{rawDescription}</Typography> : null}
       {rawErrors.length > 0 && (


### PR DESCRIPTION
We are supposed to be allowed to define custom css classes per field.
@see https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#custom-css-class-names